### PR TITLE
Limit monster preferences to enclosure

### DIFF
--- a/Scripts/SaveGame.gd
+++ b/Scripts/SaveGame.gd
@@ -91,12 +91,13 @@ func load_game() -> void:
 			
 			if i == "_all_monster_types":
 				new_object = new_object as EnclosureManager
-				var _all_monster_types: Dictionary[Utils.MONSTER_TYPES, int] = {}
-				var _all_monster_preferences: Dictionary[Utils.MONSTER_TYPES, float] = {}
+				var _all_monster_types: Dictionary[int, Array] = {}
+				var _all_monster_preferences: Dictionary[int, Array] = {}
 				
 				for j in node_data[i]:
-					_all_monster_types[int(j)] = int(node_data["_all_monster_types"][j])
-					_all_monster_preferences[int(j)] = float(node_data["_all_monster_preferences"][j])
+					_all_monster_types[int(j)] = node_data["_all_monster_types"][j]
+					_all_monster_preferences[int(j)] = node_data["_all_monster_preferences"][j]
+				
 				
 				new_object._all_monster_types = _all_monster_types
 				new_object._all_monster_preferences = _all_monster_preferences

--- a/Scripts/SignalBus.gd
+++ b/Scripts/SignalBus.gd
@@ -5,5 +5,5 @@ signal money_tick
 signal money_updated(money: IdleNumber)
 signal enclosure_cost_updated(cost: IdleNumber)
 signal selected_enclosure_changed(new_enclosure: Enclosure)
-signal monsters_updated(new_monster: Monster)
+signal monsters_updated(new_monster: Monster, enclosure_index: int)
 signal monster_pressed(monster: Monster)

--- a/_Scenes/Enclosure/enclosure.gd
+++ b/_Scenes/Enclosure/enclosure.gd
@@ -41,7 +41,7 @@ func try_add_monster(new_monster: Monster) -> bool:
 	monsters.append(new_monster)
 	
 	_update_capacity()
-	SignalBus.monsters_updated.emit(new_monster)
+	SignalBus.monsters_updated.emit(new_monster, Globals.enclosure_manager.selected_enclosure)
 	return true
 
 func _update_capacity() -> void:

--- a/_Scenes/Game/game.gd
+++ b/_Scenes/Game/game.gd
@@ -73,7 +73,7 @@ func complete_training() -> void:
 	timer = get_tree().create_timer(load_time / 2)
 	Globals.ui_manager.toggle_loading(true)
 	
-	SignalBus.monsters_updated.emit(null)
+	SignalBus.monsters_updated.emit(null, -1)
 	
 	training.queue_free()
 	SaveGame.save_game()

--- a/_Scenes/UI/train_menu.gd
+++ b/_Scenes/UI/train_menu.gd
@@ -20,7 +20,7 @@ func _on_enclosure_changed(new_enclosure: Enclosure) -> void:
 	
 	_update_monsters()
 
-func _update_monsters(_monster: Monster = null) -> void:
+func _update_monsters(_monster: Monster = null, _enclosure_index: int = -1) -> void:
 	var monsters_to_display: Array[Monster] = current_enclosure.monsters
 	
 	var to_display_length: int = len(monsters_to_display)

--- a/_Scenes/UI/ui.tscn
+++ b/_Scenes/UI/ui.tscn
@@ -241,6 +241,7 @@ pivot_offset = Vector2(50, 0)
 text = "X"
 
 [node name="MonsterInfo" type="Button" parent="."]
+visible = false
 z_index = 5
 anchors_preset = 15
 anchor_right = 1.0

--- a/_Scenes/UI/ui_manager.gd
+++ b/_Scenes/UI/ui_manager.gd
@@ -84,7 +84,7 @@ func _on_train_menu_container_pressed() -> void:
 func _on_close_train_menu_pressed() -> void:
 	toggle_train_menu_visibility(false)
 
-func _on_monster_pressed(monster: Monster) -> void:
+func _on_monster_pressed(_monster: Monster) -> void:
 	toggle_monster_info_visibility(true)
 
 func _on_monster_info_pressed() -> void:


### PR DESCRIPTION
## Issue
Monster preferences are currently in relation all enclosures instead of within the intended enclosure. So, this requires some further filtering to work as designed.
## Requirements
- [x] Limit monster preferences per enclosure

Closes #33.