### PR TITLE
feat: Added monster animations

### DIFF
--- a/_Scenes/Enclosure/enclosure.gd
+++ b/_Scenes/Enclosure/enclosure.gd
@@ -55,7 +55,7 @@ func save() -> Dictionary:
 			"monster_data": monster.monster_data.resource_path,
 			"pos_x": monster.position.x,
 			"pos_y": monster.position.y,
-			"scale": monster.scale.x,
+			"scale": monster.scale.y,
 			"produce": monster.produce.array_to_num(),
 			"training_cost": monster.training_cost.array_to_num(),
 			"level": monster.level

--- a/_Scenes/Monster/monster.gd
+++ b/_Scenes/Monster/monster.gd
@@ -1,6 +1,8 @@
 class_name Monster
 extends TextureButton
 
+var animate_tween: Tween
+
 var monster_data: BaseMonster
 var produce: IdleNumber
 var training_cost: IdleNumber

--- a/_Scenes/UI/ui.tscn
+++ b/_Scenes/UI/ui.tscn
@@ -43,6 +43,10 @@ swipe_threshold = 200
 swipe_duration = 0.3
 metadata/_edit_use_anchors_ = true
 
+[node name="MonsterMove" type="Timer" parent="EnclosureManager"]
+wait_time = 10.0
+autostart = true
+
 [node name="InfoBar" type="Panel" parent="."]
 anchors_preset = -1
 anchor_right = 0.71


### PR DESCRIPTION
## Issue(s)
Right now, the elements on the player's screen are very rigid. The only element that is updated is the money count, which makes the game quite dull to look at. To add some visual interest I will move the monsters to a random location if a *movement chance* threshold is met.

## Requirements
- [x] Move the monsters around the enclosure if a random chance is met
- [x] Normalize animation times relative to distance travelled

Closes #35 .