### PR TITLE
Run random bonus events

### DIFF
--- a/Scripts/SaveGame.gd
+++ b/Scripts/SaveGame.gd
@@ -80,12 +80,12 @@ func load_game() -> void:
 				var save_time: Dictionary = node_data["_save_time"]
 				var curr_time: Dictionary = Time.get_datetime_dict_from_system()
 				
-				var currency_per_tick: String = node_data["currency_per_tick"]
+				var currency_per_tick: String = node_data["_currency_per_tick"]
 				var afk_earnings: IdleNumber = _generate_afk_earnings(save_time, curr_time, currency_per_tick)
 				new_object.adjust_money(afk_earnings.array_to_num())
 				continue
 			
-			if i == "enclosure_cost" or i == "currency_per_tick":
+			if i == "enclosure_cost" or i == "_currency_per_tick":
 				_setup_idle_number(new_object, i, node_data)
 				continue
 			
@@ -186,7 +186,6 @@ func _generate_afk_earnings(save_time: Dictionary, curr_time: Dictionary, curren
 	var years: int = max(0, curr_time["year"] - save_time["year"])
 	
 	# CALCULATE EARNINGS
-	
 	second_total.multiply(seconds)
 	minute_total.multiply(minutes)
 	hour_total.multiply(hours)

--- a/Scripts/SignalBus.gd
+++ b/Scripts/SignalBus.gd
@@ -1,9 +1,16 @@
 extends Node
 
+# GAME FLOW
 signal loading_screen_timeout
+
+# MONEY/COSTS
 signal money_tick
 signal money_updated(money: IdleNumber)
+signal currency_per_tick_updated(new_currency_per_tick: IdleNumber)
 signal enclosure_cost_updated(cost: IdleNumber)
+
+# GAMEPLAY UPDATES
 signal selected_enclosure_changed(new_enclosure: Enclosure)
 signal monsters_updated(new_monster: Monster, enclosure_index: int)
 signal monster_pressed(monster: Monster)
+signal event_started(multiplier: float, duration: float)

--- a/_Scenes/EventPopup/event_popup.gd
+++ b/_Scenes/EventPopup/event_popup.gd
@@ -1,0 +1,35 @@
+class_name EventPopup extends Button
+
+@onready
+var icon_container: Control = $IconContainer
+
+@export_range(2.0, 5.0, 0.1)
+var min_multiplier: float = 2.0
+@export_range(2.0, 10.0, 0.1)
+var max_multiplier: float = 2.0
+@export_range(1.0, 20.0, 1.0)
+var min_duration: float = 5.0
+@export_range(10.0, 300.0, 5.0)
+var max_duration: float = 5.0
+
+@export
+var shrink_duration: float = 5.0
+
+func _on_event_pressed() -> void:
+	var multiplier: float = Utils.rng.randf_range(min_multiplier, max_multiplier)
+	var duration: float = Utils.rng.randf_range(min_duration, max_duration)
+	SignalBus.event_started.emit(multiplier, duration)
+	queue_free()
+
+func _on_despawn_timeout() -> void:
+	var shrink: Tween = get_tree().create_tween()
+	shrink.set_parallel()
+	shrink.tween_property(
+		icon_container,
+		"scale",
+		Vector2.ZERO,
+		shrink_duration
+	)
+	
+	await shrink.finished
+	queue_free()

--- a/_Scenes/EventPopup/event_popup.gd.uid
+++ b/_Scenes/EventPopup/event_popup.gd.uid
@@ -1,0 +1,1 @@
+uid://do7rd6fe30udt

--- a/_Scenes/EventPopup/event_popup.tscn
+++ b/_Scenes/EventPopup/event_popup.tscn
@@ -1,0 +1,59 @@
+[gd_scene load_steps=7 format=3 uid="uid://dyyik5hm76y8e"]
+
+[ext_resource type="Script" uid="uid://do7rd6fe30udt" path="res://_Scenes/EventPopup/event_popup.gd" id="1_4mm0v"]
+[ext_resource type="Texture2D" uid="uid://baxrai53v1hmb" path="res://Assets/Sprites/money.png" id="2_pg7ek"]
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_pg7ek"]
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_vrto4"]
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_fs3gl"]
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_gbgvd"]
+
+[node name="EventPopup" type="Button"]
+process_mode = 3
+custom_minimum_size = Vector2(75, 75)
+anchors_preset = -1
+anchor_right = 0.0868056
+anchor_bottom = 0.154321
+theme_override_styles/focus = SubResource("StyleBoxEmpty_pg7ek")
+theme_override_styles/hover = SubResource("StyleBoxEmpty_vrto4")
+theme_override_styles/pressed = SubResource("StyleBoxEmpty_fs3gl")
+theme_override_styles/normal = SubResource("StyleBoxEmpty_gbgvd")
+action_mode = 0
+script = ExtResource("1_4mm0v")
+metadata/_edit_use_anchors_ = true
+
+[node name="Despawn" type="Timer" parent="."]
+wait_time = 5.0
+one_shot = true
+autostart = true
+ignore_time_scale = true
+
+[node name="IconContainer" type="Control" parent="."]
+layout_mode = 1
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -50.0
+offset_top = -50.0
+offset_right = 50.0
+offset_bottom = 50.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Icon" type="TextureRect" parent="IconContainer"]
+texture_filter = 1
+layout_mode = 2
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+texture = ExtResource("2_pg7ek")
+expand_mode = 3
+stretch_mode = 6
+
+[connection signal="pressed" from="." to="." method="_on_event_pressed"]
+[connection signal="timeout" from="Despawn" to="." method="_on_despawn_timeout"]

--- a/_Scenes/Game/game.gd
+++ b/_Scenes/Game/game.gd
@@ -4,10 +4,19 @@ extends Node2D
 @onready
 var _save_game_timer: Timer = $SaveGame
 @onready
+var _spawn_random_event_timer: Timer = $SpawnRandomEvent
+@onready
 var _training_parent: CanvasLayer = $TrainingParent
+@onready
+var _events: Node2D = $Events
 
-@export var load_time: float = 2
+@export var load_time: float = 2.0
 var timer: SceneTreeTimer
+
+var RANDOM_EVENT = preload("res://_Scenes/RandomEvent/random_event.tscn")
+@export_group("RandomEvent settings")
+@export_range(60.0, 600.0, 5.0) var min_event_cooldown: float
+@export_range(300.0, 900.0, 5.0) var max_event_cooldown: float
 
 const TRAINING = preload("res://_Scenes/Training/Neutral/training_neutral_01.tscn")
 var training: Training
@@ -44,7 +53,11 @@ func _ready() -> void:
 	Globals.ui_manager.toggle_loading(false)
 	
 	_save_game_timer.start()
+	_spawn_random_event_timer.start(_get_event_cooldown())
 	get_tree().paused = false
+
+func _get_event_cooldown() -> float:
+	return Utils.rng.randf_range(min_event_cooldown, max_event_cooldown)
 
 func load_training(monster_to_train: Monster) -> void:
 	_save_game_timer.stop()
@@ -88,3 +101,8 @@ func complete_training() -> void:
 func _on_save_game_timeout() -> void:
 	SaveGame.save_game()
 	_save_game_timer.start()
+
+func _on_spawn_random_event_timeout() -> void:
+	var event: RandomEvent = RANDOM_EVENT.instantiate()
+	_events.add_child(event)
+	_spawn_random_event_timer.start(_get_event_cooldown())

--- a/_Scenes/Game/game.gd
+++ b/_Scenes/Game/game.gd
@@ -8,7 +8,7 @@ var _spawn_random_event_timer: Timer = $SpawnRandomEvent
 @onready
 var _training_parent: CanvasLayer = $TrainingParent
 @onready
-var _events: Node2D = $Events
+var _events: CanvasLayer = $EventContainer
 
 @export var load_time: float = 2.0
 var timer: SceneTreeTimer
@@ -49,6 +49,7 @@ func _ready() -> void:
 	
 	Globals.ui_manager.update_enclosure_cost_label(Globals.enclosure_manager.enclosure_cost)
 	Globals.ui_manager.update_money_label(Globals.money_manager.get_money())
+	Globals.ui_manager.update_currency_per_tick_label(Globals.money_manager.get_currency_per_tick())
 	
 	Globals.ui_manager.toggle_loading(false)
 	

--- a/_Scenes/Game/game.tscn
+++ b/_Scenes/Game/game.tscn
@@ -12,12 +12,13 @@
 
 [node name="Game" type="Node2D"]
 script = ExtResource("1_tkjlu")
+min_event_cooldown = 60.0
+max_event_cooldown = 300.0
 
-[node name="Events" type="Node2D" parent="."]
-
-[node name="MoneyManager" parent="." instance=ExtResource("2_c7f46")]
+[node name="MoneyManager" parent="." node_paths=PackedStringArray("event_overlay") instance=ExtResource("2_c7f46")]
 process_mode = 3
 starting_money = "100"
+event_overlay = NodePath("../EventOverlay")
 
 [node name="ProgressionManager" type="Node2D" parent="." groups=["Persist"]]
 process_mode = 3
@@ -42,13 +43,15 @@ mouse_filter = 2
 [node name="TrainingParent" type="CanvasLayer" parent="."]
 layer = 5
 
+[node name="EventContainer" type="CanvasLayer" parent="."]
+layer = 99
+
 [node name="SaveGame" type="Timer" parent="."]
 wait_time = 10.0
 one_shot = true
 
 [node name="SpawnRandomEvent" type="Timer" parent="."]
 one_shot = true
-ignore_time_scale = true
 
 [connection signal="timeout" from="SaveGame" to="." method="_on_save_game_timeout"]
 [connection signal="timeout" from="SpawnRandomEvent" to="." method="_on_spawn_random_event_timeout"]

--- a/_Scenes/Game/game.tscn
+++ b/_Scenes/Game/game.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=3 uid="uid://bi7aj25brt7l6"]
+[gd_scene load_steps=10 format=3 uid="uid://bi7aj25brt7l6"]
 
 [ext_resource type="PackedScene" uid="uid://33dpkdbpx7lf" path="res://_Scenes/UI/ui.tscn" id="1_65hya"]
 [ext_resource type="Script" uid="uid://btclhvrlpb346" path="res://_Scenes/Game/game.gd" id="1_tkjlu"]
@@ -8,9 +8,12 @@
 [ext_resource type="Resource" uid="uid://bq63fe1u7chxe" path="res://Resources/Monsters/salamander.tres" id="5_3ebme"]
 [ext_resource type="Resource" uid="uid://bqp3ucknwv2rc" path="res://Resources/Monsters/sylph.tres" id="6_eaye3"]
 [ext_resource type="Resource" uid="uid://4gclqar1tqq5" path="res://Resources/Monsters/undine.tres" id="7_yi3ji"]
+[ext_resource type="Material" uid="uid://pjns3nq2o8h" path="res://_Scenes/RandomEvent/event_overlay.tres" id="9_3ebme"]
 
 [node name="Game" type="Node2D"]
 script = ExtResource("1_tkjlu")
+
+[node name="Events" type="Node2D" parent="."]
 
 [node name="MoneyManager" parent="." instance=ExtResource("2_c7f46")]
 process_mode = 3
@@ -23,6 +26,19 @@ locked_monsters = Array[ExtResource("4_6a16g")]([ExtResource("5_3ebme"), ExtReso
 
 [node name="UI" parent="." instance=ExtResource("1_65hya")]
 
+[node name="EventOverlay" type="CanvasLayer" parent="."]
+layer = 2
+visible = false
+
+[node name="Shader" type="ColorRect" parent="EventOverlay"]
+material = ExtResource("9_3ebme")
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+
 [node name="TrainingParent" type="CanvasLayer" parent="."]
 layer = 5
 
@@ -30,4 +46,9 @@ layer = 5
 wait_time = 10.0
 one_shot = true
 
+[node name="SpawnRandomEvent" type="Timer" parent="."]
+one_shot = true
+ignore_time_scale = true
+
 [connection signal="timeout" from="SaveGame" to="." method="_on_save_game_timeout"]
+[connection signal="timeout" from="SpawnRandomEvent" to="." method="_on_spawn_random_event_timeout"]

--- a/_Scenes/MoneyManager/money_manager.gd
+++ b/_Scenes/MoneyManager/money_manager.gd
@@ -5,7 +5,11 @@ extends Node2D
 var starting_money: String
 var _money: IdleNumber
 
-signal money_updated(value: IdleNumber)
+@export
+var event_overlay: CanvasLayer
+
+var current_multiplier: float = 1.0
+var multiplier_timer: SceneTreeTimer
 
 func _ready() -> void:
 	if Globals.money_manager != null and Globals.money_manager != self:
@@ -36,7 +40,7 @@ func adjust_money(value: String) -> void:
 
 func can_afford(money_to_check: IdleNumber) -> bool:
 	return _money.compare(money_to_check)
-	
+
 func try_purchase(price: String) -> bool:
 	if not can_afford(IdleNumber.new(price)):
 		return false
@@ -44,7 +48,25 @@ func try_purchase(price: String) -> bool:
 	adjust_money("-%s" % price)
 	
 	return true
+
+func generate_currency(currency: String) -> void:
+	var extra_currency: IdleNumber = IdleNumber.new(currency)
+	if current_multiplier != 1.0:
+		extra_currency.multiply(current_multiplier)
+	adjust_money(extra_currency.array_to_num())
+
+func start_currency_event(multiplier: float, time_to_run: float) -> void:
+	event_overlay.visible = true
+	current_multiplier = multiplier
+	multiplier_timer = get_tree().create_timer(time_to_run)
 	
+	if not multiplier_timer.timeout.is_connected(end_currency_event):
+		multiplier_timer.timeout.connect(end_currency_event)
+
+func end_currency_event() -> void:
+	event_overlay.visible = false
+	current_multiplier = 1.0
+
 func save() -> Dictionary:
 	return {
 		"path": get_path(),

--- a/_Scenes/RandomEvent/event_overlay.gdshader
+++ b/_Scenes/RandomEvent/event_overlay.gdshader
@@ -1,0 +1,17 @@
+shader_type canvas_item;
+
+uniform vec3 _VignetteColor : source_color = vec3(0.5, 0.15, 0.156);
+uniform float _VignetteAlpha : hint_range(0.0, 1.0, 0.01) = 0.5;
+uniform float _VignetteDarken : hint_range(0.0, 1.0, 0.01) = 0.0;
+uniform float _VignetteFalloff : hint_range(1.0, 5.0, 0.01) = 1.0;
+uniform float _VignetteFalloffIncrease : hint_range(0.0, 5.0, 0.01) = 0.0;
+uniform float _VignetteStrength : hint_range(1.0, 5.0, 0.01) = 1.0;
+
+void fragment() {
+	float distance_from_center = distance(vec2(0.5, 0.5), UV);
+	float falloff = _VignetteFalloff - (_VignetteFalloffIncrease * _VignetteAlpha);
+	float alpha = pow(distance_from_center, falloff);
+	alpha *= _VignetteStrength;
+	
+	COLOR = vec4(_VignetteColor * (1.0 - _VignetteDarken * alpha), min(alpha, _VignetteAlpha));
+}

--- a/_Scenes/RandomEvent/event_overlay.gdshader.uid
+++ b/_Scenes/RandomEvent/event_overlay.gdshader.uid
@@ -1,0 +1,1 @@
+uid://b5te6gf3jypid

--- a/_Scenes/RandomEvent/event_overlay.tres
+++ b/_Scenes/RandomEvent/event_overlay.tres
@@ -1,0 +1,12 @@
+[gd_resource type="ShaderMaterial" load_steps=2 format=3 uid="uid://pjns3nq2o8h"]
+
+[ext_resource type="Shader" uid="uid://b5te6gf3jypid" path="res://_Scenes/RandomEvent/event_overlay.gdshader" id="1_fpp7l"]
+
+[resource]
+shader = ExtResource("1_fpp7l")
+shader_parameter/_VignetteColor = Color(1, 0.566667, 0, 1)
+shader_parameter/_VignetteAlpha = 1.0
+shader_parameter/_VignetteDarken = 0.75
+shader_parameter/_VignetteFalloff = 3.2
+shader_parameter/_VignetteFalloffIncrease = 0.3
+shader_parameter/_VignetteStrength = 1.0

--- a/_Scenes/RandomEvent/random_event.gd
+++ b/_Scenes/RandomEvent/random_event.gd
@@ -1,0 +1,37 @@
+class_name RandomEvent extends Control
+
+@onready var despawn_timer: Timer = $Despawn
+@onready var event_button: TextureButton = $EventButton
+
+@export_group("Event settings")
+@export_subgroup("Reward settings")
+@export_range(1.0, 5.0, 0.1) var min_reward_multiplier: float = 1.0
+@export_range(1.0, 50.0, 0.1) var max_reward_multiplier: float = 2.0
+@export_subgroup("Duration settings")
+@export_range(5.0, 30.0, 0.1) var min_reward_duration: float = 5.0
+@export_range(5.0, 300.0, 0.1) var max_reward_duration: float = 15.0
+
+@export_group("Shrink settings")
+@export_range(0.0, 30.0, 0.1) var time_to_despawn: float = 10.0
+@export_range(0.0, 10.0, 0.1) var time_to_shrink: float = 3.0
+
+func _ready() -> void:
+	despawn_timer.start(time_to_despawn - time_to_shrink)
+
+func _on_button_pressed() -> void:
+	var reward_multiplier: float = Utils.rng.randf_range(min_reward_multiplier, max_reward_multiplier)
+	var event_run_time: float = Utils.rng.randf_range(min_reward_duration, max_reward_duration)
+	Globals.money_manager.start_currency_event(reward_multiplier, event_run_time)
+	queue_free()
+
+func _on_despawn_timeout() -> void:
+	var shrink: Tween = get_tree().create_tween()
+	shrink.tween_property(
+		event_button,
+		"scale",
+		Vector2.ZERO,
+		time_to_shrink
+	)
+	
+	await shrink.finished
+	queue_free()

--- a/_Scenes/RandomEvent/random_event.gd.uid
+++ b/_Scenes/RandomEvent/random_event.gd.uid
@@ -1,0 +1,1 @@
+uid://cn0o0s48ngkt5

--- a/_Scenes/RandomEvent/random_event.tscn
+++ b/_Scenes/RandomEvent/random_event.tscn
@@ -1,0 +1,29 @@
+[gd_scene load_steps=3 format=3 uid="uid://4trcp5cfwoks"]
+
+[ext_resource type="Script" uid="uid://cn0o0s48ngkt5" path="res://_Scenes/RandomEvent/random_event.gd" id="1_qw2tx"]
+[ext_resource type="Texture2D" uid="uid://baxrai53v1hmb" path="res://Assets/Sprites/money.png" id="2_bmbhg"]
+
+[node name="RandomEvent" type="CenterContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_right = -1024.0
+offset_bottom = -520.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_qw2tx")
+min_reward_multiplier = 2.0
+max_reward_multiplier = 10.0
+max_reward_duration = 60.0
+
+[node name="EventButton" type="TextureButton" parent="."]
+layout_mode = 2
+texture_normal = ExtResource("2_bmbhg")
+stretch_mode = 6
+
+[node name="Despawn" type="Timer" parent="."]
+one_shot = true
+ignore_time_scale = true
+
+[connection signal="pressed" from="EventButton" to="." method="_on_button_pressed"]
+[connection signal="timeout" from="Despawn" to="." method="_on_despawn_timeout"]

--- a/_Scenes/Training/Neutral/training_neutral_01.gd
+++ b/_Scenes/Training/Neutral/training_neutral_01.gd
@@ -106,12 +106,16 @@ func complete() -> void:
 	_monster_in_training.level += 1
 	_monster_in_training.training_cost.multiply(training_cost_multiplier)
 	
-	var old_produce: String = _monster_in_training.produce.display_value(2)
-	_monster_in_training.produce.multiply(2)
-	var new_produce: String = _monster_in_training.produce.display_value(2)
+	var curr_produce: IdleNumber = IdleNumber.new(_monster_in_training.produce.array_to_num())
+	curr_produce.multiply(10.0)
+	var old_produce: String = curr_produce.display_value(2)
 	
-	old_produce_label.text = "OLD: $%s" % old_produce
-	new_produce_label.text = "NEW: $%s" % new_produce
+	_monster_in_training.produce.multiply(2)
+	curr_produce.multiply(2)
+	var new_produce: String = curr_produce.display_value(2)
+	
+	old_produce_label.text = "OLD: $%s/s" % old_produce
+	new_produce_label.text = "NEW: $%s/s" % new_produce
 	
 	training_finished.visible = true
 	

--- a/_Scenes/UI/enclosure_manager.gd
+++ b/_Scenes/UI/enclosure_manager.gd
@@ -4,7 +4,6 @@ extends Control
 const ENCLOSURE_SCENE = preload("res://_Scenes/Enclosure/enclosure.tscn")
 var _tween: Tween
 
-var currency_per_tick: IdleNumber = IdleNumber.new()
 var _all_monster_types: Dictionary[int, Array] = {}
 var _all_monster_preferences: Dictionary[int, Array] = {}
 
@@ -38,7 +37,6 @@ func _ready() -> void:
 	
 	Globals.enclosure_manager = self
 	
-	SignalBus.money_tick.connect(_generate_currency)
 	SignalBus.monsters_updated.connect(_on_monster_added)
 	SignalBus.selected_enclosure_changed.connect(get_max_monster_y)
 	
@@ -73,7 +71,6 @@ func setup_enclosures_from_save() -> void:
 
 func get_max_monster_y(new_enclosure: Enclosure) -> void:
 	max_monster_pos_y =  4.0 / 7.0 * new_enclosure.size.y + 100
-	print("max_monster_pos_y: %d" % max_monster_pos_y)
 
 func get_random_monster_pos(monster: Monster) -> Vector2:
 	return Vector2(Utils.rng.randf_range(10, enclosures[selected_enclosure].size.x - 10 - monster.size.x), Utils.rng.randf_range(max_monster_pos_y - 100, max_monster_pos_y))
@@ -164,9 +161,6 @@ func _handle_swipe() -> void:
 	selected_enclosure = next_enclosure
 	SignalBus.selected_enclosure_changed.emit(enclosures[selected_enclosure])
 
-func _generate_currency() -> void:
-	Globals.money_manager.generate_currency(currency_per_tick.array_to_num())
-
 func _on_monster_added(new_monster: Monster, enclosure_index: int) -> void:
 	if new_monster == null || enclosure_index == -1:
 		_get_currency_per_tick()
@@ -221,7 +215,7 @@ func _get_currency_per_tick() -> void:
 			currency_to_add.multiply(_all_monster_preferences[i][monster.monster_data.type])
 			currency.add(currency_to_add.array_to_num())
 	
-	currency_per_tick = currency
+	SignalBus.currency_per_tick_updated.emit(currency)
 
 func save() -> Dictionary:
 	return {
@@ -229,7 +223,6 @@ func save() -> Dictionary:
 		"selected_enclosure": selected_enclosure,
 		"_all_monster_types": _all_monster_types,
 		"_all_monster_preferences": _all_monster_preferences,
-		"currency_per_tick": currency_per_tick.array_to_num(),
 		"enclosure_cost": enclosure_cost.array_to_num(),
 	}
 

--- a/_Scenes/UI/enclosure_manager.gd
+++ b/_Scenes/UI/enclosure_manager.gd
@@ -165,7 +165,7 @@ func _handle_swipe() -> void:
 	SignalBus.selected_enclosure_changed.emit(enclosures[selected_enclosure])
 
 func _generate_currency() -> void:
-	Globals.money_manager.adjust_money(currency_per_tick.array_to_num())
+	Globals.money_manager.generate_currency(currency_per_tick.array_to_num())
 
 func _on_monster_added(new_monster: Monster, enclosure_index: int) -> void:
 	if new_monster == null || enclosure_index == -1:

--- a/_Scenes/UI/ui.tscn
+++ b/_Scenes/UI/ui.tscn
@@ -56,7 +56,7 @@ offset_bottom = 0.207993
 grow_horizontal = 2
 theme = ExtResource("2_gu6w1")
 
-[node name="Money" type="Panel" parent="InfoBar"]
+[node name="Money" type="HBoxContainer" parent="InfoBar"]
 z_index = 1
 layout_mode = 0
 offset_right = 242.0
@@ -64,35 +64,35 @@ offset_bottom = 100.0
 theme = ExtResource("2_gu6w1")
 
 [node name="MoneyIcon" type="TextureRect" parent="InfoBar/Money"]
-layout_mode = 1
-anchors_preset = -1
-anchor_left = 0.062
-anchor_top = 0.14
-anchor_right = 0.351
-anchor_bottom = 0.84
-offset_left = -0.00400066
-offset_right = 0.0579987
-grow_vertical = 2
+layout_mode = 2
 texture = ExtResource("4_eusta")
 expand_mode = 3
 
-[node name="MoneyLabel" type="RichTextLabel" parent="InfoBar/Money"]
+[node name="VBoxContainer" type="VBoxContainer" parent="InfoBar/Money"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/separation = -20
+alignment = 1
+
+[node name="MoneyLabel" type="RichTextLabel" parent="InfoBar/Money/VBoxContainer"]
 unique_name_in_owner = true
 texture_filter = 1
-layout_mode = 1
-anchors_preset = -1
-anchor_left = 0.985
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_left = -144.37
-offset_top = 26.0
-offset_right = -9.0
-offset_bottom = -28.0
+layout_mode = 2
+size_flags_vertical = 3
 theme = ExtResource("2_gu6w1")
 text = "10.3Tvg"
 scroll_active = false
 autowrap_mode = 0
+horizontal_alignment = 1
+vertical_alignment = 2
 drag_and_drop_selection_enabled = false
+
+[node name="CurrencyPerTickLabel" type="Label" parent="InfoBar/Money/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 6
+text = "+12.3M/s"
+horizontal_alignment = 1
 
 [node name="AddEnclosure" type="Button" parent="InfoBar"]
 z_index = 5

--- a/_Scenes/UI/ui_manager.gd
+++ b/_Scenes/UI/ui_manager.gd
@@ -9,6 +9,8 @@ var _loading_label: RichTextLabel = $%LoadingLabel
 @onready
 var _money: RichTextLabel = $%MoneyLabel
 @onready
+var _currency_per_tick: Label = $%CurrencyPerTickLabel
+@onready
 var _enclosure_cost: Label = $%EnclosureCost
 
 @onready
@@ -31,12 +33,15 @@ func _ready() -> void:
 	Globals.ui_manager = self
 	
 	SignalBus.money_updated.connect(update_money_label)
+	SignalBus.currency_per_tick_updated.connect(update_currency_per_tick_label)
 	update_money_label(Globals.money_manager.get_money())
+	update_currency_per_tick_label(Globals.money_manager.get_currency_per_tick())
 	
 	SignalBus.enclosure_cost_updated.connect(update_enclosure_cost_label)
 	update_enclosure_cost_label(Globals.enclosure_manager.enclosure_cost)
 	
 	SignalBus.monster_pressed.connect(_on_monster_pressed)
+	SignalBus.event_started.connect(_on_event_started)
 	
 	toggle_train_menu_visibility(false)
 	toggle_monster_info_visibility(false)
@@ -65,6 +70,21 @@ func toggle_loading(value: bool = !_loading.visible) -> void:
 
 func update_money_label(value: IdleNumber) -> void:
 	_money.text = "$%s" % value.display_value(2)
+
+func update_currency_per_tick_label(value: IdleNumber) -> void:
+	print(value.array_to_num())
+	var temp_value: IdleNumber = IdleNumber.new(value.array_to_num())
+	temp_value.multiply(10.0)
+	
+	var display_value: String = temp_value.display_value(2)
+	_currency_per_tick.text = "+$%s/s" % display_value
+
+func _on_event_started(multiplier: float, _duration: float) -> void:
+	var currency: IdleNumber = Globals.money_manager.get_currency_per_tick()
+	var new_currency: IdleNumber = IdleNumber.new(currency.array_to_num())
+	new_currency.multiply(multiplier)
+	
+	update_currency_per_tick_label(new_currency)
 
 func update_enclosure_cost_label(value: IdleNumber) -> void:
 	_enclosure_cost.text = "$%s" % value.display_value(2)


### PR DESCRIPTION
## Issue
Currently, the game is pretty monotonous in terms of active gameplay. If the player has enough money, they can purchase a monster and then train it. As far as playing the game - more than occasionally checking the game, managing their monsters for 5 minutes, then closing the game again - there isn't much. To increase the playability of the game further, adding random events that will generate more currency or similar to reward the player for active gameplay would be a good start.

## Requirements
- [x] Create an event node with tap functionality
- [x] Spawn the event periodically with random:
  - [x] Currency multipliers
  - [x] Position
  - [x] Cooldown between a reasonable range (value between min - max timeout)

Closes #6.